### PR TITLE
Phonenumber class now splits calling code and national number internally

### DIFF
--- a/client-api/src/main/java/net/goui/phonenumber/AbstractPhoneNumberClassifier.java
+++ b/client-api/src/main/java/net/goui/phonenumber/AbstractPhoneNumberClassifier.java
@@ -203,9 +203,7 @@ public abstract class AbstractPhoneNumberClassifier {
   }
 
   final <R> R withDecomposed(PhoneNumber number, BiFunction<DigitSequence, DigitSequence, R> fn) {
-    DigitSequence digits = number.getDigits();
-    DigitSequence cc = extractSupportedCallingCode(digits);
-    return fn.apply(cc, digits.getSuffix(digits.length() - cc.length()));
+    return fn.apply(number.getCallingCode(), number.getNationalNumber());
   }
 
   /**
@@ -240,21 +238,6 @@ public abstract class AbstractPhoneNumberClassifier {
    */
   public final MatchResult match(PhoneNumber phoneNumber) {
     return withDecomposed(phoneNumber, rawClassifier::match);
-  }
-
-  private DigitSequence extractSupportedCallingCode(DigitSequence digits) {
-    checkArgument(
-        digits.length() >= 3, "E.164 phone numbers must be at least 3 digits long: +%s", digits);
-    DigitSequence.Digits it = digits.iterate();
-    int intValue = it.next();
-    checkArgument(
-        intValue > 0, "E.164 phone numbers must not start with a leading zero: +%s", digits);
-    DigitSequence cc = null;
-    for (; cc == null && intValue < 100; intValue = (10 * intValue) + it.next()) {
-      cc = callingCodes.get(intValue);
-    }
-    checkArgument(cc != null, "invalid or unsupported calling code for E.164 number: +%s", digits);
-    return cc;
   }
 
   private static int intValueOf(DigitSequence cc) {

--- a/client-api/src/main/java/net/goui/phonenumber/PhoneNumber.java
+++ b/client-api/src/main/java/net/goui/phonenumber/PhoneNumber.java
@@ -1,22 +1,25 @@
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- Copyright (c) 2023, David Beaumont (https://github.com/hagbard).
+Copyright (c) 2023, David Beaumont (https://github.com/hagbard).
 
- This program and the accompanying materials are made available under the terms of the
- Eclipse Public License v. 2.0 available at https://www.eclipse.org/legal/epl-2.0, or the
- Apache License, Version 2.0 available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under the terms of the
+Eclipse Public License v. 2.0 available at https://www.eclipse.org/legal/epl-2.0, or the
+Apache License, Version 2.0 available at https://www.apache.org/licenses/LICENSE-2.0.
 
- SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
 package net.goui.phonenumber;
 
 /** Designed to accommodate expected features for "inline classes" and "records". */
 public interface PhoneNumber {
-  /** Returns an efficient representation of the digits in this phone number. */
+  /** Returns all digits of this phone number. */
   DigitSequence getDigits();
 
-  /** Returns the Nth digit value (in the range {@code {0..9}}) in this phone number. */
-  int getDigit(int n);
+  /** Returns the country calling code of this phone number (e.g. '1' or '44'). */
+  DigitSequence getCallingCode();
+
+  /** Returns the national number of this phone number without a national dialing prefix. */
+  DigitSequence getNationalNumber();
 
   /** Returns the number of digits in this phone number. */
   int length();

--- a/client-api/src/test/java/net/goui/phonenumber/PhoneNumbersTest.java
+++ b/client-api/src/test/java/net/goui/phonenumber/PhoneNumbersTest.java
@@ -17,17 +17,18 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class E164PhoneNumbersTest {
+public class PhoneNumbersTest {
   @Test
   public void testParse() {
-    PhoneNumber number = PhoneNumbers.parseE164("+44 123 456789");
+    PhoneNumber number = PhoneNumbers.fromE164("+44123456789");
     assertThat(number.length()).isEqualTo(11);
     String s = number.toString();
     assertThat(s).isEqualTo("+44123456789");
+    DigitSequence digits = number.getDigits();
     for (int n = 0; n < number.length(); n++) {
-      assertThat(number.getDigit(n)).isEqualTo(s.charAt(n + 1) - '0');
+      assertThat(digits.getDigit(n)).isEqualTo(s.charAt(n + 1) - '0');
     }
-    assertThat(number).isEqualTo(PhoneNumbers.parseE164("+44 123 456 789"));
-    assertThat(number).isNotEqualTo(PhoneNumbers.parseE164("+44 123 456 999"));
+    assertThat(number).isEqualTo(PhoneNumbers.fromE164("+44123456789"));
+    assertThat(number).isNotEqualTo(PhoneNumbers.fromE164("+44123456999"));
   }
 }

--- a/examples/src/main/java/net/goui/phonenumbers/examples/Simple.java
+++ b/examples/src/main/java/net/goui/phonenumbers/examples/Simple.java
@@ -10,7 +10,7 @@
 
 package net.goui.phonenumbers.examples;
 
-import static net.goui.phonenumber.PhoneNumbers.parseE164;
+import static net.goui.phonenumber.PhoneNumbers.fromE164;
 
 import net.goui.phonenumber.AbstractPhoneNumberClassifier.SchemaVersion;
 import net.goui.phonenumber.PhoneNumber;
@@ -21,34 +21,34 @@ public class Simple {
     LibPhoneNumberClassifier compact = LibPhoneNumberClassifier.load(SchemaVersion.of("goui.net/libphonenumber/dfa/compact", 1));
     LibPhoneNumberClassifier precise = LibPhoneNumberClassifier.load(SchemaVersion.of("goui.net/libphonenumber/dfa/precise", 1));
 
-    PhoneNumber number = parseE164("+16502123456");
+    PhoneNumber number = fromE164("+16502123456");
     System.out.format("%s: %s\n", number, precise.forType().identify(number));
     System.out.format("%s: %s\n", number, compact.forType().identify(number));
     System.out.format("%s: %s\n", number, precise.testLength(number));
     System.out.format("%s: %s\n", number, compact.testLength(number));
 
-    PhoneNumber prefix = parseE164("+917678");
+    PhoneNumber prefix = fromE164("+917678");
     System.out.format("%s: %s\n", prefix, compact.forType().getPossibleValues(prefix));
-    prefix = parseE164("+9176781");
-    System.out.format("%s: %s\n", prefix, compact.forType().getPossibleValues(prefix));
-
-    prefix = parseE164("+9176782");
+    prefix = fromE164("+9176781");
     System.out.format("%s: %s\n", prefix, compact.forType().getPossibleValues(prefix));
 
-    prefix = parseE164("+917678");
+    prefix = fromE164("+9176782");
+    System.out.format("%s: %s\n", prefix, compact.forType().getPossibleValues(prefix));
+
+    prefix = fromE164("+917678");
     System.out.format("%s: %s\n", prefix, precise.forType().getPossibleValues(prefix));
-    prefix = parseE164("+9176781");
+    prefix = fromE164("+9176781");
     System.out.format("%s: %s\n", prefix, precise.forType().getPossibleValues(prefix));
-    prefix = parseE164("+9176782");
+    prefix = fromE164("+9176782");
     System.out.format("%s: %s\n", prefix, precise.forType().getPossibleValues(prefix));
 
-    prefix = parseE164("+15661");
+    prefix = fromE164("+15661");
     System.out.format("%s: %s\n", prefix, precise.forType().getPossibleValues(prefix));
     System.out.format("%s: %s\n", prefix, compact.forType().getPossibleValues(prefix));
     System.out.format("%s: %s\n", prefix, precise.forRegion().getPossibleValues(prefix));
     System.out.format("%s: %s\n", prefix, compact.forRegion().getPossibleValues(prefix));
 
-    prefix = parseE164("+15671");
+    prefix = fromE164("+15671");
     System.out.format("%s: %s\n", prefix, precise.match(prefix));
     System.out.format("%s: %s\n", prefix, compact.match(prefix));
 
@@ -57,7 +57,7 @@ public class Simple {
     System.out.format("%s: %s\n", prefix, precise.testLength(prefix));
     System.out.format("%s: %s\n", prefix, compact.testLength(prefix));
 
-    prefix = parseE164("+447700312345");
+    prefix = fromE164("+447700312345");
     System.out.format("%s: %s\n", prefix, compact.forRegion().getPossibleValues(prefix));
     System.out.format("%s: %s\n", prefix, precise.forRegion().getPossibleValues(prefix));
   }

--- a/javascript/src/phone-number.ts
+++ b/javascript/src/phone-number.ts
@@ -21,9 +21,9 @@ export class PhoneNumber {
       + "\uefff\u001f\u0000\u0000\u0000\u0000\u0000\u0000\u0101\u0000\u0000\u01b4\u4040\u014f"
       + "\u0000\u0000\u0000\u0000\ufdff\u000b\u005f";
 
-  static parseE164(e164: string): PhoneNumber {
+  static fromE164(e164: string): PhoneNumber {
     let seq = e164.startsWith("+") ? e164.substring(1) : e164;
-    if (seq.length <= 3) {
+    if (seq.length < 3) {
       throw new Error(`E.164 numbers must be at least 3 digits: ${e164}`);
     }
     let cc: number = PhoneNumber.digitOf(seq, 0);
@@ -41,7 +41,7 @@ export class PhoneNumber {
   }
 
   private static digitOf(s: string, n: number): number {
-    var d = s.charCodeAt(n) - PhoneNumber.ASCII_0;
+    let d = s.charCodeAt(n) - PhoneNumber.ASCII_0;
     if (d < 0 || d > 9) {
       throw new Error(`Invalid decimal digit in: ${s}`);
     }
@@ -63,11 +63,11 @@ export class PhoneNumber {
     return this.nn;
   }
 
-  getDigitSequence(): DigitSequence {
+  getDigits(): DigitSequence {
     return this.cc.append(this.nn);
   }
 
   toString(): string {
-    return "+" + this.getDigitSequence();
+    return "+" + this.getCallingCode() + this.getNationalNumber();
   }
 }

--- a/javascript/tests/index.test.ts
+++ b/javascript/tests/index.test.ts
@@ -52,14 +52,14 @@ const pnc = new TestClassifier("tests/lpn_dfa_compact.json");
 describe("AbstractPhoneNumberClassifier", () => {
 
   test('getPossibleValues_uniqueValues', () => {
-    expect(pnc.forRegion().getPossibleValues(PhoneNumber.parseE164("+447700112345")))
+    expect(pnc.forRegion().getPossibleValues(PhoneNumber.fromE164("+447700112345")))
       .toEqual(new Set(["GB"]));
-    expect(pnc.forRegion().getPossibleValues(PhoneNumber.parseE164("+447700312345")))
+    expect(pnc.forRegion().getPossibleValues(PhoneNumber.fromE164("+447700312345")))
       .toEqual(new Set(["JE"]));
     });
 
   test('getPossibleValues_multipleValues', () => {
-    expect(pnc.forRegion().getPossibleValues(PhoneNumber.parseE164("+447700")))
+    expect(pnc.forRegion().getPossibleValues(PhoneNumber.fromE164("+447700")))
       .toEqual(new Set(["GB", "JE"]));
     });
 });


### PR DESCRIPTION
Calling codes now verified when PhoneNumber instance is made, so guaranteed to be valid when passed to classifier.
However classifier may have subset of calling code data available.